### PR TITLE
Revert "Enable Windows"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3634e03ee13dd637fd7196b80474bf44c64d3eba1dd069ea92b94926702a60bd
 
 build:
-  number: 2
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
   entry_points:
@@ -29,6 +29,7 @@ requirements:
     - setuptools
     - six
   run:
+    - __unix # to skip win, as a noarch package
     - looseversion
     - python >={{ python_min }}
     - six


### PR DESCRIPTION
Reverts conda-forge/rethinkdb-python-feedstock#6

This was made accidentally. This package does not have a PyTorch dependency, so Windows support remains unchanged.